### PR TITLE
Fix theme provider and add mode toggle

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -5,6 +5,7 @@ import { getMessages } from "next-intl/server";
 import { Poppins } from "next/font/google";
 
 import { UserProvider } from "@/providers/UserProvider";
+import { ThemeProvider } from "@/context/theme-context";
 import "./globals.css";
 import LazyLoadedComponents from "./LazyLoadedComponents";
 
@@ -60,11 +61,13 @@ export default async function RootLayout({
       </head>
       <body>
         <NextIntlClientProvider locale={params.locale} messages={messages}>
-          <UserProvider>
-            {children}
-            <LazyLoadedComponents />
-            <Toaster />
-          </UserProvider>
+          <ThemeProvider>
+            <UserProvider>
+              {children}
+              <LazyLoadedComponents />
+              <Toaster />
+            </UserProvider>
+          </ThemeProvider>
         </NextIntlClientProvider>
 
         {/* Load non-critical scripts */}

--- a/components/Navbar.tsx
+++ b/components/Navbar.tsx
@@ -17,6 +17,7 @@ import LanguageSwitcher from "./LanguageSwitcher";
 import LogoutBtn from "./LogoutBtn";
 import UpgradeButton from "./UpgradeButton";
 import MuteButton from "./MuteButton"; // Import the new MuteButton component
+import { ThemeToggle } from "./ui/theme-toggle";
 
 export default function Navbar({ user, profile }) {
   // State to handle mobile menu toggle
@@ -106,6 +107,7 @@ export default function Navbar({ user, profile }) {
 
           <div className="flex items-center gap-2">
             <LanguageSwitcher />
+            <ThemeToggle />
 
             <div className="mx-3 h-5 w-px bg-slate-700/50"></div>
 
@@ -161,13 +163,14 @@ export default function Navbar({ user, profile }) {
           </h1>
         </Link>
 
-        <div className="flex items-center gap-3">
-          {/* Add NotificationBell to mobile view too */}
+          <div className="flex items-center gap-3">
+            {/* Add NotificationBell to mobile view too */}
 
-          {/* Add MuteButton component to mobile view */}
-          {/* {user?.id && <MuteButton userId={user.id} />} */}
+            {/* Add MuteButton component to mobile view */}
+            {/* {user?.id && <MuteButton userId={user.id} />} */}
 
-          <LanguageSwitcher />
+            <LanguageSwitcher />
+            <ThemeToggle />
 
           {/* Mobile Menu Button */}
           <button

--- a/context/theme-context.tsx
+++ b/context/theme-context.tsx
@@ -2,7 +2,7 @@
 
 import React, { createContext, useContext, useEffect, useState } from "react";
 
-type Theme = "dark" | "dark";
+type Theme = "light" | "dark";
 
 type ThemeContextType = {
   theme: Theme;
@@ -26,26 +26,21 @@ export function ThemeProvider({ children }: { children: React.ReactNode }) {
   // Load theme preference from localStorage on mount
   useEffect(() => {
     setMounted(true);
-    const savedTheme = localStorage.getItem("theme") as Theme;
-    if (savedTheme) {
-      setTheme(savedTheme);
-      document.documentElement.classList.toggle(
-        "light-mode",
-        savedTheme === "dark",
-      );
-    }
+    const savedTheme = (localStorage.getItem("theme") as Theme) || "dark";
+    setTheme(savedTheme);
+    document.documentElement.classList.toggle("light-mode", savedTheme === "light");
   }, []);
 
   // Update localStorage and document class when theme changes
   useEffect(() => {
     if (mounted) {
       localStorage.setItem("theme", theme);
-      document.documentElement.classList.toggle("light-mode", theme === "dark");
+      document.documentElement.classList.toggle("light-mode", theme === "light");
     }
   }, [theme, mounted]);
 
   const toggleTheme = () => {
-    setTheme((prevTheme) => (prevTheme === "dark" ? "dark" : "dark"));
+    setTheme((prevTheme) => (prevTheme === "dark" ? "light" : "dark"));
   };
 
   const value = {


### PR DESCRIPTION
## Summary
- fix `Theme` type and toggle logic
- add `ThemeProvider` at app root
- insert `ThemeToggle` in desktop and mobile nav

## Testing
- `npm run lint` *(fails: `next` not found)*